### PR TITLE
Fix `npm install --production`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "author": "Rob Lourens",
   "license": "MIT",
-  "devDependencies": {
+  "dependencies": {
     "github-releases": "^0.3.2",
     "mkdirp": "^0.5.1",
     "progress": "^1.1.8",


### PR DESCRIPTION
Currently,

    $ npm install --production vscode-ripgrep

gives

    Error: Cannot find module 'github-releases'

This is because `github-releases`, `mkdirp`, `progress`, and `yauzl` are listed as `devDependencies`, but they're actually required to install (not just develop) `vscode-ripgrep`. Listing them as `dependencies` stops `npm install --production` from crashing.

Thanks to @asgdf for discovering this bug in https://github.com/Zarel/Pokemon-Showdown/pull/3569#issuecomment-306093371