### PR TITLE
GH-10: Appended the `.exe` file extension to the path on Windows.

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,1 @@
+export declare const rgPath: string;

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,4 +2,4 @@
 
 const path = require('path');
 
-module.exports.rgPath = path.join(__dirname, '../bin/rg');
+module.exports.rgPath = path.join(__dirname, `../bin/rg${process.platform === 'win32' ? '.exe' : ''}`);

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.8.1",
   "description": "Downloads the ripgrep binary shipped in VS Code",
   "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/roblourens/vscode-ripgrep"


### PR DESCRIPTION
Also added the type definition for the path of the binary.

Closes #10.
Closes #11.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>