### PR TITLE
Use cached binary whenever possible

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -15,6 +15,11 @@ const { binPath } = require('./common');
 
 function download(opts, assetName, downloadDest) {
     return new Promise((resolve, reject) => {
+        const assetDownloadPath = path.join(downloadDest, assetName);
+        // We can just use the cached binary
+        if (fs.existsSync(assetDownloadPath)) {
+            return resolve(assetDownloadPath)
+        }
         const github = new GitHub({
             user: 'roblourens',
             repo: 'ripgrep',
@@ -35,7 +40,6 @@ function download(opts, assetName, downloadDest) {
                 return reject(new Error(`No asset named ${assetName} found`));
             }
 
-            const assetDownloadPath = path.join(downloadDest, assetName);
 
             github.downloadAsset(asset, (error, istream) => {
                 if (error) {


### PR DESCRIPTION
This is especially useful when used inside an environment where any network access is blocked like [Flathub](https://github.com/flathub/com.visualstudio.code.oss)

I suppose that there is no necessity to re-download the same binary as the filename remains to be the same; if so, please inform me, thank you very much!