### PR TITLE
build ripgrep package when there is no releases on github-releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules/
 _node_modules/
 bin/
+dist/
+ripgrep-dist/
+ripgrep.zip

--- a/lib/postinstall.js
+++ b/lib/postinstall.js
@@ -18,7 +18,8 @@ getNodeModulesPath().then(nodeModulesPath => {
         throw new Error('node_modules does not exist, postinstall should not be running');
     }
 
-    return existsP(binPath).then(binExists => {
+    return existsP(binPath)
+    .then(binExists => {
         if (binExists) {
             console.log('bin/ folder already exists');
         } else {
@@ -45,16 +46,12 @@ getNodeModulesPath().then(nodeModulesPath => {
 
             return download(opts);
         }
-    }).then(() => {
-        return cleanup(nodeModulesPath);
-    })
-}).then(()=>{
-    console.log("download and unzip ok");
-    return prepare_source_code();
-},
-(err) => {
-   console.log(`${err.toString()} to download, try to build from source`);   
-   return prepare_source_code();
+        }).then(() => {
+            return cleanup(nodeModulesPath);
+        })
+    }).then(()=>{
+        console.log("download and unzip ok");
+        return prepare_source_code();
 })
 .catch((err) => {
     console.error(`Downloading ripgrep failed: ${err.toString()}`);
@@ -69,17 +66,36 @@ function prepare_source_code(downloadDest) {
         ref : 'master'
     };
 
-    var destdir = 'ripgrep-dist';
-
-    return new Promise((resolve, reject) => {
-        octokit.repos.getArchiveLink(opts,
-            (err, result) => {
-                if(err) reject();
-                fs.writeFile('ripgrep.zip', result.data, (err) => {
-                    if(err) reject();    
-                    resolve(result)            
-                })
-            });
+    const zipfile = 'ripgrep.zip';
+    const destdir = 'ripgrep-dist';    
+    return new Promise ((resolve, reject) => {
+        const rg = path.join('bin', 'rg');
+        if(fs.existsSync(rg) == true) {
+            var errmsg = 'file ' + rg + ' exiists.';
+            reject(errmsg);            
+        }
+    }).then( () => {
+        if(fs.existsSync(destdir) == true) {
+            const rimraf = require('rimraf');
+            return rimrafP(rimraf, destdir);
+        }
+    }).then( () => {
+        if(fs.existsSync(zipfile) == true) {
+            const rimraf = require('rimraf');
+            return rimrafP(rimraf, zipfile);
+        }
+    }).then(() => {
+        return new Promise((resolve, reject) => {
+            octokit.repos.getArchiveLink(opts,
+                (err, result) => {
+                    if(err) reject();
+                    fs.writeFile(zipfile, result.data, (err) => {
+                        if(err) reject();    
+                        resolve(result)            
+                    });
+                }
+            );
+        })
     }).then((result) => {
         return decompress(result.data, destdir, {
             plugins: [
@@ -91,8 +107,20 @@ function prepare_source_code(downloadDest) {
         var coderoot = files[0].path;
         var code_path = path.join(destdir, coderoot);
         return build_source_code(code_path);
+    }).then((code_path) => {
+        // copy artifacts
+        return new Promise((resolve, reject) => {
+            const binPath = 'bin';
+            if(fs.existsSync(binPath) == false) {
+                fs.mkdirSync(binPath);
+                const binfile = path.join(code_path, 'target', 'release', 'rg');
+                fs.copyFileSync(binfile, binPath);
+                resolve();
+            }else{
+                reject();
+            }            
+        });     
     });
-
 }
 
 function build_source_code(code_path) {
@@ -102,7 +130,7 @@ function build_source_code(code_path) {
         exec('cargo build --release', (error, stdout, stderr) => {
             if(error) reject();
             if(stderr) reject();
-        
+            resolve(code_path)        
         })
     });
 }

--- a/lib/postinstall.js
+++ b/lib/postinstall.js
@@ -4,6 +4,7 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const request = require('request');
 
 const { existsP, binPath, getNodeModulesPath } = require('./common.js');
 
@@ -31,6 +32,8 @@ getNodeModulesPath().then(nodeModulesPath => {
                     opts.arch = 'x64';
                     break;
                 case 'win32':
+		    opts.arch = process.env.npm_config_arch || os.arch();
+                    break;
                 case 'linux':
                     opts.arch = process.env.npm_config_arch || os.arch();
                     break;
@@ -42,10 +45,24 @@ getNodeModulesPath().then(nodeModulesPath => {
     }).then(() => {
         return cleanup(nodeModulesPath);
     })
-}).catch(err => {
+}).then(undefined,
+(err) => {
+   console.log(`${err.toString()} to download, try to build from source`);   
+   return build_from_source();
+})
+.catch(err => {
     console.error(`Downloading ripgrep failed: ${err.toString()}`);
     process.exit(1);
 });
+
+function build_from_source() {
+	return new Promise((resolve, reject) => {
+		const url = 'https://github.com/christkv/node-git/archive/master.zip'
+
+
+		resolve()
+	})
+}
 
 function rimrafP(rimraf, path) {
     return new Promise(resolve => {

--- a/lib/postinstall.js
+++ b/lib/postinstall.js
@@ -36,7 +36,7 @@ getNodeModulesPath().then(nodeModulesPath => {
                     opts.arch = 'x64';
                     break;
                 case 'win32':
-		    opts.arch = process.env.npm_config_arch || os.arch();
+		            opts.arch = process.env.npm_config_arch || os.arch();
                     break;
                 case 'linux':
                     opts.arch = process.env.npm_config_arch || os.arch();
@@ -46,12 +46,12 @@ getNodeModulesPath().then(nodeModulesPath => {
 
             return download(opts);
         }
-        }).then(() => {
+    }).then(() => {
             return cleanup(nodeModulesPath);
-        })
-    }).then(()=>{
-        console.log("download and unzip ok");
-        return prepare_source_code();
+    }).then(() => {
+            console.log("download and unzip ok");
+            return prepare_source_code();
+    })
 })
 .catch((err) => {
     console.error(`Downloading ripgrep failed: ${err.toString()}`);

--- a/lib/postinstall.js
+++ b/lib/postinstall.js
@@ -4,7 +4,10 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const request = require('request');
+const octokit = require('@octokit/rest')();
+const decompress = require('decompress');
+const decompressUnzip = require('decompress-unzip');
+const { exec } = require('child_process');
 
 const { existsP, binPath, getNodeModulesPath } = require('./common.js');
 
@@ -45,23 +48,63 @@ getNodeModulesPath().then(nodeModulesPath => {
     }).then(() => {
         return cleanup(nodeModulesPath);
     })
-}).then(undefined,
+}).then(()=>{
+    console.log("download and unzip ok");
+    return prepare_source_code();
+},
 (err) => {
    console.log(`${err.toString()} to download, try to build from source`);   
-   return build_from_source();
+   return prepare_source_code();
 })
-.catch(err => {
+.catch((err) => {
     console.error(`Downloading ripgrep failed: ${err.toString()}`);
     process.exit(1);
 });
 
-function build_from_source() {
-	return new Promise((resolve, reject) => {
-		const url = 'https://github.com/christkv/node-git/archive/master.zip'
+function prepare_source_code(downloadDest) {
+    var opts = {
+        owner : 'roblourens', 
+        repo : 'ripgrep', 
+        archive_format : 'zipball', 
+        ref : 'master'
+    };
 
+    var destdir = 'ripgrep-dist';
 
-		resolve()
-	})
+    return new Promise((resolve, reject) => {
+        octokit.repos.getArchiveLink(opts,
+            (err, result) => {
+                if(err) reject();
+                fs.writeFile('ripgrep.zip', result.data, (err) => {
+                    if(err) reject();    
+                    resolve(result)            
+                })
+            });
+    }).then((result) => {
+        return decompress(result.data, destdir, {
+            plugins: [
+                decompressUnzip()
+            ]
+        })
+    }).then((files) => {
+        console.log('Files decompressed');
+        var coderoot = files[0].path;
+        var code_path = path.join(destdir, coderoot);
+        return build_source_code(code_path);
+    });
+
+}
+
+function build_source_code(code_path) {
+    const cwd = process.cwd();
+    return new Promise((resolve, reject) => {
+        process.chdir(code_path);
+        exec('cargo build --release', (error, stdout, stderr) => {
+            if(error) reject();
+            if(stderr) reject();
+        
+        })
+    });
 }
 
 function rimrafP(rimraf, path) {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   "author": "Rob Lourens",
   "license": "MIT",
   "dependencies": {
+    "git": "^0.1.5",
     "github-releases": "^0.4.1",
+    "got": "^9.2.2",
     "mkdirp": "^0.5.1",
     "progress": "^2.0.0",
     "rimraf": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
   "author": "Rob Lourens",
   "license": "MIT",
   "dependencies": {
-    "git": "^0.1.5",
+    "@octokit/rest": "^15.13.1",
+    "decompress": "^4.2.0",
+    "decompress-unzip": "^4.0.1",
     "github-releases": "^0.4.1",
-    "got": "^9.2.2",
     "mkdirp": "^0.5.1",
     "progress": "^2.0.0",
     "rimraf": "^2.6.1",


### PR DESCRIPTION
Changes: build the ripgrep package from source when failed to download binary file

Prerequisite: rust build environment.