### PR TITLE
Enable builds on ppc64le via TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: bash
+
+os : linux-ppc64le
+
+addons:
+  apt:
+    packages:
+      - zip
+      - cargo
+
+rust: 1.32.0
+
+script:
+  - sh run_ripgrep_build.sh
+
+deploy:
+  provider: releases
+  api_key: "$api_key"
+  file: "/home/travis/ripgrep/ripgrep-linux-ppc64le.zip"
+  skip_cleanup: true
+  on:
+    tags: true

--- a/run_ripgrep_build.sh
+++ b/run_ripgrep_build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+cd ~
+echo "git clone https://github.com/roblourens/ripgrep.git"
+git clone https://github.com/roblourens/ripgrep.git
+echo "cd ripgrep/"
+cd ripgrep/
+echo "cargo build --release --target=powerpc64le-unknown-linux-gnu --features 'pcre2'"
+cargo build --release --target=powerpc64le-unknown-linux-gnu --features 'pcre2'
+echo "strip ./target/powerpc64le-unknown-linux-gnu/release/rg"
+strip ./target/powerpc64le-unknown-linux-gnu/release/rg
+echo "zip -j "ripgrep-linux-ppc64le.zip" ./target/powerpc64le-unknown-linux-gnu/release/rg"
+zip -j "ripgrep-linux-ppc64le.zip" ./target/powerpc64le-unknown-linux-gnu/release/rg
+echo "target/powerpc64le-unknown-linux-gnu/release/rg --version"
+target/powerpc64le-unknown-linux-gnu/release/rg --version
+


### PR DESCRIPTION
The changes in this PR will build roblourens/ripgrep repository on TravisCI Power native machine, and then upload the generated .tar file to github under roblourens/vscode-ripgrep releases. The upload to github is only triggered if the git commit is tagged. User needs to setup his/her personal access token in the TravisCI UI as a environment variable "api_key" in order to allow TravisCI to access the github repository.