### PR TITLE
Print file path to console when using cached download

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -20,7 +20,7 @@ function download(opts, assetName, downloadDest) {
 
         // We can just use the cached binary
         if (fs.existsSync(assetDownloadPath)) {
-            console.log('Using cached download');
+            console.log('Using cached download: ' + assetDownloadPath);
             return resolve(assetDownloadPath)
         }
 


### PR DESCRIPTION
I spent the whole morning debugging a build that was failing because this package kept saying `Error: end of central directory record signature not found`. Finally I was able to fix it by removing the corrupt cached file, but I had to change the code to find the file location. The script should always print that path so it will be easier to find the cache in such a situation.